### PR TITLE
Feature/pragma 0.4.0 into 0.4.16

### DIFF
--- a/7/7-1/7-1-2-2_SimpleStorage.sol
+++ b/7/7-1/7-1-2-2_SimpleStorage.sol
@@ -9,7 +9,7 @@ contract SimpleStorage {
         storedData = x;
     }
 
-    function get() constant returns (uint) {
+    function get() view returns (uint) {
         return storedData;
     }
 }

--- a/7/7-1/7-1-2-2_SimpleStorage.sol
+++ b/7/7-1/7-1-2-2_SimpleStorage.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract SimpleStorage {

--- a/7/7-1/7-1-2-9_SimpleStorageOwner.sol
+++ b/7/7-1/7-1-2-9_SimpleStorageOwner.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract SimpleStorageOwner {

--- a/7/7-1/7-1-2-9_SimpleStorageOwner.sol
+++ b/7/7-1/7-1-2-9_SimpleStorageOwner.sol
@@ -19,7 +19,7 @@ contract SimpleStorageOwner {
         storedData = x;
     }
 
-    function get() constant returns (uint) {
+    function get() view returns (uint) {
         return storedData;
     }
 }

--- a/7/7-2/7-2-1-1_Booleans.sol
+++ b/7/7-2/7-2-1-1_Booleans.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.4.16;
 
 contract Booleans {
 
-    function getTrue() constant returns (bool) {
+    function getTrue() pure returns (bool) {
         bool a = true;
         bool b = false;
         return a || b;
     }
 
-    function getFalse() constant returns (bool) {
+    function getFalse() pure returns (bool) {
         bool a = false;
         bool b = true;
         return a && b;

--- a/7/7-2/7-2-1-1_Booleans.sol
+++ b/7/7-2/7-2-1-1_Booleans.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract Booleans {

--- a/7/7-2/7-2-1-2_Integers.sol
+++ b/7/7-2/7-2-1-2_Integers.sol
@@ -17,8 +17,8 @@ contract Integers {
         return 3 / 0;
     }
 
-    function shift() constant returns (uint[2]) {
-        uint[2] a;
+    function shift() pure returns (uint[2]) {
+        uint[2] memory a;
         a[0] = 16 << 2;
         a[1] = 16 >> 2;
         return a;

--- a/7/7-2/7-2-1-2_Integers.sol
+++ b/7/7-2/7-2-1-2_Integers.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract Integers {

--- a/7/7-2/7-2-1-2_Integers.sol
+++ b/7/7-2/7-2-1-2_Integers.sol
@@ -3,17 +3,17 @@ pragma solidity ^0.4.16;
 
 contract Integers {
 
-    function getTwo() constant returns (uint) {
+    function getTwo() pure returns (uint) {
         uint a = 3;
         uint b = 2;
         return a / b * 2;
     }
 
-    function getThree() constant returns (uint) {
+    function getThree() pure returns (uint) {
         return 3 / 2 * 2;
     }
 
-    function divByZero() constant returns (uint) {
+    function divByZero() pure returns (uint) {
         return 3 / 0;
     }
 

--- a/7/7-2/7-2-1-3_Address.sol
+++ b/7/7-2/7-2-1-3_Address.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract Address {

--- a/7/7-2/7-2-1-3_Address.sol
+++ b/7/7-2/7-2-1-3_Address.sol
@@ -17,15 +17,11 @@ contract Address {
     }
 
     function send(address _to, uint _amount) {
-        if (!_to.send(_amount)) {
-            throw;
-        }
+        require(_to.send(_amount));
     }
 
     function call(address _to, uint _amount) {
-        if (!_to.call.value(_amount).gas(1000000)()) {
-            throw;
-        }
+        require(_to.call.value(_amount).gas(1000000)());
     }
 
     function withDraw() {
@@ -35,8 +31,6 @@ contract Address {
 
     function withDraw2() {
         address to = msg.sender;
-        if (!to.call.value(this.balance).gas(1000000)()) {
-            throw;
-        }
+        require(to.call.value(this.balance).gas(1000000)());
     }
 }

--- a/7/7-2/7-2-1-3_Address.sol
+++ b/7/7-2/7-2-1-3_Address.sol
@@ -5,7 +5,7 @@ contract Address {
 
     function() payable {}
 
-    function getBalance(address _t) constant returns (uint) {
+    function getBalance(address _t) view returns (uint) {
         if (_t == address(0)) {
             _t = this;
         }

--- a/7/7-2/7-2-1-4_Bytes.sol
+++ b/7/7-2/7-2-1-4_Bytes.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract Bytes {

--- a/7/7-2/7-2-1-5_Enum.sol
+++ b/7/7-2/7-2-1-5_Enum.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract Enum {

--- a/7/7-2/7-2-1-6_Selector.sol
+++ b/7/7-2/7-2-1-6_Selector.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract Selector {

--- a/7/7-2/7-2-2-1_DataLocation.sol
+++ b/7/7-2/7-2-2-1_DataLocation.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract DataLocation {

--- a/7/7-2/7-2-2-2_Arrays.sol
+++ b/7/7-2/7-2-2-2_Arrays.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract Arrays {

--- a/7/7-2/7-2-2-3_MemoryArrays.sol
+++ b/7/7-2/7-2-2-3_MemoryArrays.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract MemoryArrays {

--- a/7/7-2/7-2-2-4_ArrayLiterals.sol
+++ b/7/7-2/7-2-2-4_ArrayLiterals.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract ArrayLiterals {

--- a/7/7-2/7-2-2-5_ArrayLiteralsNotCompiled.sol
+++ b/7/7-2/7-2-2-5_ArrayLiteralsNotCompiled.sol
@@ -1,5 +1,5 @@
 // This will not compile.
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract ArrayLiteralsNotCompiled {

--- a/7/7-2/7-2-2-6_ArrayContract.sol
+++ b/7/7-2/7-2-2-6_ArrayContract.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract ArrayContract {uint[2 ** 20] m_aLotOfIntegers;

--- a/7/7-2/7-2-2-7_Structs.sol
+++ b/7/7-2/7-2-2-7_Structs.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract Structs {

--- a/7/7-2/7-2-3-1_Mappings.sol
+++ b/7/7-2/7-2-3-1_Mappings.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract Mappings {

--- a/7/7-2/7-2-4-1_Operator.sol
+++ b/7/7-2/7-2-4-1_Operator.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract Operator {

--- a/7/7-2/7-2-5-1_DeleteExample.sol
+++ b/7/7-2/7-2-5-1_DeleteExample.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract DeleteExample {

--- a/7/7-2/7-2-6-1_Conversions.sol
+++ b/7/7-2/7-2-6-1_Conversions.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract Conversions {

--- a/7/7-2/7-2-6-2_ConversionTruncate.sol
+++ b/7/7-2/7-2-6-2_ConversionTruncate.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract ConversionTruncate {

--- a/7/7-3/7-3-1-2_Units.sol
+++ b/7/7-3/7-3-1-2_Units.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract Units {

--- a/7/7-4/7-4-1-1_InputParams.sol
+++ b/7/7-4/7-4-1-1_InputParams.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract InputParams {

--- a/7/7-4/7-4-1-2_OutputParams.sol
+++ b/7/7-4/7-4-1-2_OutputParams.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract OutputParams {

--- a/7/7-4/7-4-1-3_OutputWithReturn.sol
+++ b/7/7-4/7-4-1-3_OutputWithReturn.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract OutputWithReturn {

--- a/7/7-4/7-4-2-10_Sharer.sol
+++ b/7/7-4/7-4-2-10_Sharer.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract Sharer {

--- a/7/7-4/7-4-2-1_Controls.sol
+++ b/7/7-4/7-4-2-1_Controls.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract Controls {

--- a/7/7-4/7-4-2-2_InternalFunctionCalls.sol
+++ b/7/7-4/7-4-2-2_InternalFunctionCalls.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract InternalFunctionCalls {

--- a/7/7-4/7-4-2-3_ExternalFunction.sol
+++ b/7/7-4/7-4-2-3_ExternalFunction.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract InfoFeed {

--- a/7/7-4/7-4-2-4_NamedCalls.sol
+++ b/7/7-4/7-4-2-4_NamedCalls.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract NamedCalls {

--- a/7/7-4/7-4-2-5_Omitted.sol
+++ b/7/7-4/7-4-2-5_Omitted.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract Omitted {

--- a/7/7-4/7-4-2-6_CreateContract.sol
+++ b/7/7-4/7-4-2-6_CreateContract.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract Target {

--- a/7/7-4/7-4-2-7_Assignment.sol
+++ b/7/7-4/7-4-2-7_Assignment.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract Assignment {

--- a/7/7-4/7-4-2-8_ScopingErrors.sol
+++ b/7/7-4/7-4-2-8_ScopingErrors.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract ScopingErrors {

--- a/7/7-4/7-4-2-9_Declarations.sol
+++ b/7/7-4/7-4-2-9_Declarations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract Declarations {

--- a/7/7-5/7-5-2-1_SimpleStorageOwner.sol
+++ b/7/7-5/7-5-2-1_SimpleStorageOwner.sol
@@ -18,6 +18,6 @@ contract SimpleStorageOwner {
     function set(uint x) onlyOwner {
         storedData = x;}
 
-    function get() constant returns (uint) {
+    function get() view returns (uint) {
         return storedData;}
 }

--- a/7/7-5/7-5-2-1_SimpleStorageOwner.sol
+++ b/7/7-5/7-5-2-1_SimpleStorageOwner.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract SimpleStorageOwner {

--- a/7/7-5/7-5-3-1_Constant.sol
+++ b/7/7-5/7-5-3-1_Constant.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.16;
 
 
 contract Constant {


### PR DESCRIPTION
# ディレクトリ7内のコードを修正

## solidity version 0.4.0の箇所を、0.4.16へ変更　※修正理由は下記

- version 0.4.17 以降から、関数にvisibility修飾子（public）などが明示されていないと、コンパイラが警告を出すようになった。
- 最新 version 0.4.23 では、constructor の記法が変更された。そのため、既存の記法だとコンパイラが警告を出すようになった。
- 以上の理由から、書籍の修正範囲が広範になることを懸念し、0.4.16 までの version upに留めた。

## 修正箇所
- 関数のconstant修飾子を、view、pureへ修正
- エラーハンドリングにthrowを使用している箇所を修正